### PR TITLE
Update default.hbs

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -30,8 +30,8 @@
 
     <!-- Main JS Initialization -->
     <script src="{{asset "js/init.js"}}"></script>
-    <link href='http://fonts.googleapis.com/css?family=Megrim:400' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Merriweather+Sans:300,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Megrim:400' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Merriweather+Sans:300,700' rel='stylesheet' type='text/css'>
 
     <noscript>
         <link rel="stylesheet" href="{{asset "css/skel.css"}}" />


### PR DESCRIPTION
using HTTPS for Google Fonts reduces browser errors caused by insecure contents when using Aventurine on HTTPS-secured Ghost sites
